### PR TITLE
Feature/marketing permissions for checkout and my acocunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,4 @@ Installation for the Custobar WooCommerce Plugin is the same as any other WordPr
 
 - Order totals include VAT but order items do not (this is the default functionality of WooCommerce)
 
-- Permission for marketing is asked in the checkout phase only for unauthenticated users. Usually customer do not register before the first order so practically this is rarely a problem. Permission is not given if it's not asked. This functionality might have to be changed if you offer a path to registration without purchase.
-
-- Permission for marketing sets _email_ and _sms_ permissions if selected. No functionality to edit this through filters at this point.
+- This plugin adds support for Custobar marketing permissions. The plugin also adds a Rest API endpoint that allows syncing marketing permissions from Custobar to WooCommerce. Please contact Custobar for further information on how to configure the needed webhook in Custobar.

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -33,35 +33,6 @@ class Plugin {
 			Sale_Sync::add_hooks();
 			Data_Upload::add_hooks();
 
-			// Marketing permission
-			// add_action('woocommerce_after_checkout_registration_form', [__CLASS__, 'ask_permission_for_marketing']);
-			// add_action('woocommerce_checkout_update_order_meta', [__CLASS__, 'save_permission_for_marketing']);
-		}
-	}
-
-	/**
-	 * Adds a checkbox field to the checkout asking for permissions for
-	 * marketing.
-	 */
-	public static function ask_permission_for_marketing( $checkout ) {
-		woocommerce_form_field(
-			'marketing_permission',
-			array(
-				'type'  => 'checkbox',
-				'class' => array( 'input-checkbox' ),
-				'label' => apply_filters(
-					'woocommerce_custobar_marketing_permission_text',
-					__( 'I would like to receive marketing messages', 'woocommerce-custobar' )
-				),
-			),
-			$checkout->get_value( 'marketing_permission' )
-		);
-	}
-
-	public static function save_permission_for_marketing( $order_id ) {
-		if ( isset( $_POST['marketing_permission'] ) && $_POST['marketing_permission'] ) {
-			update_post_meta( $order_id, '_woocommerce_custobar_can_email', esc_attr( $_POST['marketing_permission'] ) );
-			update_post_meta( $order_id, '_woocommerce_custobar_can_sms', esc_attr( $_POST['marketing_permission'] ) );
 		}
 	}
 

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -174,18 +174,6 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 				'desc' => '',
 				'id'   => 'custobar_marketing_settings',
 			),
-			'custobar_initial_can_email'  => array(
-				'name' => __( 'Initial email permission', 'woocommerce-custobar' ),
-				'type' => 'checkbox',
-				'desc' => __( 'Set can_email to "true" when exporting a new customer.', 'woocommerce-custobar' ),
-				'id'   => 'custobar_initial_can_email',
-			),
-			'custobar_initial_can_sms'    => array(
-				'name' => __( 'Initial SMS permission', 'woocommerce-custobar' ),
-				'type' => 'checkbox',
-				'desc' => __( 'Set can_sms to "true" when exporting a new customer.', 'woocommerce-custobar' ),
-				'id'   => 'custobar_initial_can_sms',
-			),
 			'section_end'                 => array(
 				'type' => 'sectionend',
 				'id'   => 'custobar_section_end',

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -60,11 +60,22 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 	 * @uses self::get_settings_api()
 	 */
 	public function save() {
-		woocommerce_update_options( $this->get_settings_api() );
-		woocommerce_update_options( $this->get_settings_fields() );
-		woocommerce_update_options( $this->get_settings_marketing() );
-	}
+		// _$POST object is used directly by WC_Admin_Settings::save_fields()
+		$data = $_POST; //phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( empty( $data ) ) {
+			return false;
+		}
+		// Regenerate custobar_wc_rest_api_secret if it does not exist or if reset requested by user.
+		if ( isset( $data['custobar_wc_rest_api_secret'] ) && ( ! $data['custobar_wc_rest_api_secret'] || ! empty( $data['custobar_wc_rest_api_secret_reset'] ) ) ) {
+			$data['custobar_wc_rest_api_secret'] = $this->generate_secret_key();
+			// Unset reset checkbox. We don't need to (and should not) save it.
+			unset( $data['custobar_wc_rest_api_secret_reset'] );
+		}
 
+		woocommerce_update_options( $this->get_settings_api(), $data );
+		woocommerce_update_options( $this->get_settings_fields(), $data );
+		woocommerce_update_options( $this->get_settings_marketing(), $data );
+	}
 
 	/**
 	 * Get API settings
@@ -75,25 +86,41 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 	public function get_settings_api() {
 
 		$settings = array(
-			'custobar_api_settings' => array(
+			'custobar_api_settings'          => array(
 				'name' => __( 'Custobar API Settings', 'woocommerce-custobar' ),
 				'type' => 'title',
 				'desc' => '',
 				'id'   => 'custobar_api_settings',
 			),
-			'custobar_api_token'    => array(
+			'custobar_api_token'             => array(
 				'name' => __( 'API Token', 'woocommerce-custobar' ),
 				'type' => 'password',
 				'desc' => __( 'Enter your Custobar API token.', 'woocommerce-custobar' ),
 				'id'   => 'custobar_api_setting_token',
 			),
-			'custobar_api_company'  => array(
+			'custobar_api_company'           => array(
 				'name' => __( 'Company Domain', 'woocommerce-custobar' ),
 				'type' => 'text',
 				'desc' => __( 'Enter the unique domain prefix for your Custobar account, for example if your Custobar account is at acme123.custobar.com then enter only acme123.', 'woocommerce-custobar' ),
 				'id'   => 'custobar_api_setting_company',
 			),
-			'section_end'           => array(
+			'custobar_rest_api_secret'       => array(
+				'name'              => __( 'Webhook Secret Key', 'woocommerce-custobar' ),
+				'type'              => 'text',
+				'desc'              => __( 'Use this value for the Authorization header when configuring webhooks in Custobar.', 'woocommerce-custobar' ),
+				'id'                => 'custobar_wc_rest_api_secret',
+				'custom_attributes' => array(
+					'readonly' => 'readonly',
+				),
+			),
+			'custobar_rest_api_secret_reset' => array(
+				'name' => __( 'Reset Secret Key', 'woocommerce-custobar' ),
+				'type' => 'checkbox',
+				'desc' => __( 'Check this box to reset webhook secret key.', 'woocommerce-custobar' ),
+				'id'   => 'custobar_wc_rest_api_secret_reset',
+			),
+
+			'section_end'                    => array(
 				'type' => 'sectionend',
 				'id'   => 'custobar_section_end',
 			),
@@ -208,14 +235,14 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 				'sale_stat'     => $sale_stat,
 				'customer_stat' => $customer_stat,
 			);
-			print $template->get();
+			print $template->get();  // @codingStandardsIgnoreLine
 
 		} elseif ( 'api' === $current_section ) {
 
 			$template       = new Template();
 			$template->name = 'api-test';
 			$template->data = array();
-			print $template->get();
+			print $template->get();  // @codingStandardsIgnoreLine
 
 			WC_Admin_Settings::output_fields( $this->get_settings_api() );
 
@@ -268,4 +295,19 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 
 	}
 
+	/**
+	 * Generates a Random String used as a secret key for inbound REST Api requests
+	 *
+	 * @return string
+	 */
+	protected function generate_secret_key() {
+		$length            = 32;
+		$characters        = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		$characters_length = strlen( $characters );
+		$random_string     = '';
+		for ( $i = 0; $i < $length; $i++ ) {
+			$random_string .= $characters[ wp_rand( 0, $characters_length - 1 ) ];
+		}
+		return $random_string;
+	}
 }

--- a/classes/data-sources/class-customer.php
+++ b/classes/data-sources/class-customer.php
@@ -79,25 +79,25 @@ class Customer extends Abstract_Data_Source {
 	}
 
 	public function get_can_email() {
+		if ( ! metadata_exists( 'user', $this->customer->get_id(), '_woocommerce_custobar_can_email' ) ) {
+			return null;
+		}
 		$can_email = get_user_meta( $this->customer->get_id(), '_woocommerce_custobar_can_email', true );
 		if ( $can_email ) {
 			return true;
 		}
-
-		// Never return false as it would override the current value in
-		// Custobar. We don't offer functionality to remove the permission.
-		return null;
+		return false;
 	}
 
 	public function get_can_sms() {
+		if ( ! metadata_exists( 'user', $this->customer->get_id(), '_woocommerce_custobar_can_sms' ) ) {
+			return null;
+		}
 		$can_sms = get_user_meta( $this->customer->get_id(), '_woocommerce_custobar_can_sms', true );
 		if ( $can_sms ) {
 			return true;
 		}
-
-		// Never return false as it would override the current value in
-		// Custobar. We don't offer functionality to remove the permission.
-		return null;
+		return false;
 	}
 
 	public function get_street_address() {

--- a/classes/data-types/class-utilities.php
+++ b/classes/data-types/class-utilities.php
@@ -37,4 +37,47 @@ class Utilities {
 		// ISO8601 formatted datetime
 		return $datetime->setTimezone( new \DateTimeZone( 'UTC' ) )->format( 'c' );
 	}
+
+	/**
+	 * Get single data item from Custobar
+	 *
+	 * @param string $data_type
+	 * @param int    $external_id
+	 * @return array|boolean|WP_Error If successfull return Custobar data as array, false if no results or WP_Error on failure
+	 */
+	public static function get_data( $data_type, $external_id ) {
+		$api_token      = \WC_Admin_Settings::get_option( 'custobar_api_setting_token', false );
+		$company_domain = \WC_Admin_Settings::get_option( 'custobar_api_setting_company', false );
+		$url            = sprintf( 'https://%s.custobar.com/api', $company_domain ) . '/data/' . $data_type . '/?external_id=' . $external_id;
+
+		$response = wp_remote_request(
+			$url,
+			array(
+				'method'  => 'GET',
+				'headers' => array(
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Token ' . $api_token,
+				),
+			)
+		);
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		$response_body = wp_remote_retrieve_body( $response );
+
+		if ( 200 === $response_code ) {
+			//Handle successfull request
+			$response_body_array = json_decode( $response_body, true );
+			// Since we are using the external key, we are expecting one result from the correct data type. Just making sure.
+			if ( isset( $response_body_array[ $data_type ] ) && 1 === count( $response_body_array[ $data_type ] ) ) {
+				return $response_body_array[ $data_type ][0];
+			} else {
+				return false;
+			}
+		} else {
+			// Return WP_Error on error
+			$error_response = json_decode( $response_body, true );
+			$error_reason   = $error_response['error']['reason'] ?? '';
+			return new \WP_Error( $response_code, $error_reason );
+		}
+	}
 }

--- a/classes/rest-api/class-rest-marketing-permissions.php
+++ b/classes/rest-api/class-rest-marketing-permissions.php
@@ -1,0 +1,77 @@
+<?php
+namespace WooCommerceCustobar\RestAPI;
+
+use WP_REST_Server;
+
+class REST_Marketing_Permissions extends \WP_REST_Controller {
+	/**
+	 * Hook into WordPress ready to init the REST API as needed.
+	 */
+	public function init() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ), 10 );
+	}
+
+	/**
+	 * Register route for marketing permissions
+	 */
+	public function register_routes() {
+		$version   = '1';
+		$namespace = 'woocommerce-custobar/v' . $version;
+		$base      = 'marketing-permissions';
+		register_rest_route(
+			$namespace,
+			'/' . $base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_marketing_permissions' ),
+					'permission_callback' => array( $this, 'update_marketing_permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Update marketing permissions
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function update_marketing_permissions( $request ) {
+		$request_body = json_decode( $request->get_body(), true );
+
+		if ( isset( $request_body['items'] ) && count( $request_body['items'] ) ) {
+			foreach ( $request_body['items'] as $customer ) {
+				// Check that customer exists
+				if ( isset( $customer['external_id'] ) && (bool) get_user_by( 'id', $customer['external_id'] ) ) {
+					// Update sms permissions if needed
+					if ( isset( $customer['can_sms'] ) ) {
+						update_user_meta( $customer['external_id'], '_woocommerce_custobar_can_sms', (bool) $customer['can_sms'] );
+					}
+					// Update email permissions if needed
+					if ( isset( $customer['can_email'] ) ) {
+						update_user_meta( $customer['external_id'], '_woocommerce_custobar_can_email', (bool) $customer['can_email'] );
+					}
+				}
+			}
+		}
+		return new \WP_REST_Response( '', 200 );
+	}
+
+	/**
+	 * Check that Authorization header matches secret key saved as option
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return bool
+	 */
+	public function update_marketing_permissions_check( $request ) {
+		$secret_key = $request->get_header( 'Authorization' );
+		if ( $secret_key && get_option( 'custobar_wc_rest_api_secret' ) === $secret_key ) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+}
+

--- a/classes/sync-classes/class-customer-sync.php
+++ b/classes/sync-classes/class-customer-sync.php
@@ -81,26 +81,7 @@ class Customer_Sync extends Data_Sync {
 			$properties     = self::format_single_item( $customer );
 			$initial_export = false;
 
-			// Have initial marketing permissions been exported?
-			if ( ! get_user_meta( $user_id, '_custobar_permissions_export', true ) ) {
-				// Push initial marketing permissions with customer object
-				$initial_export = true;
-
-				if ( 'yes' === get_option( 'custobar_initial_can_email' ) ) {
-					$properties['can_email'] = true;
-				}
-
-				if ( 'yes' === get_option( 'custobar_initial_can_sms' ) ) {
-					$properties['can_sms'] = true;
-				}
-			}
-
 			$response = self::upload_data_type_data( $properties, true );
-
-			if ( ! is_wp_error( $response ) && in_array( $response->code, array( 200, 201 ) ) && $initial_export ) {
-				// Initial export done
-				update_user_meta( $user_id, '_custobar_permissions_export', gmdate( 'c' ) );
-			}
 
 			return $response;
 

--- a/classes/sync-classes/class-customer-sync.php
+++ b/classes/sync-classes/class-customer-sync.php
@@ -173,15 +173,6 @@ class Customer_Sync extends Data_Sync {
 			return $response;
 		}
 
-		if ( in_array( $api_response->code, array( 200, 201 ) ) ) {
-			if ( $can_email || $can_sms ) {
-				// We have exported marketing permissions for these users
-				foreach ( $users as $user_id ) {
-					update_user_meta( $user_id, '_custobar_permissions_export', gmdate( 'c' ) );
-				}
-			}
-		}
-
 		// return response
 		$response->code    = $api_response->code;
 		$response->body    = $api_response->body;

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace WooCommerceCustobar;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Add Custobar marketing permissions to checkout fields
+ *
+ * @param array $checkout_fields
+ * @return void
+ */
+function woocommerce_checkout_fields( $checkout_fields = array() ) {
+
+	if ( apply_filters( 'woocommerce_custobar_show_email_permission_setting_checkout', true ) ) {
+		$checkout_fields['order']['custobar_can_email'] = array(
+			'type'     => 'checkbox',
+			'class'    => array( 'my-field-class form-row-wide' ),
+			'label'    => __( 'I would like to receive marketing messages via email', 'woocommerce-custobar' ),
+			'required' => false,
+			'default'  => true,
+		);
+	}
+	if ( apply_filters( 'woocommerce_custobar_show_sms_permission_setting_checkout', true ) ) {
+		$checkout_fields['order']['custobar_can_sms'] = array(
+			'type'     => 'checkbox',
+			'class'    => array( 'my-field-class form-row-wide' ),
+			'label'    => __( 'I would like to receive marketing messages via SMS', 'woocommerce-custobar' ),
+			'required' => false,
+			'default'  => true,
+		);
+	}
+
+	return $checkout_fields;
+}
+add_filter( 'woocommerce_checkout_fields', __NAMESPACE__ . '\\woocommerce_checkout_fields' );
+
+/**
+ * Save Custobar marketing permissions as user data
+ *
+ * @param integer $customer_id
+ * @param array   $posted
+ * @return void
+ */
+function woocommerce_checkout_update_user_meta( $customer_id, $posted ) {
+	if ( apply_filters( 'woocommerce_custobar_show_email_permission_setting_checkout', true ) ) {
+		$can_email = ( isset( $posted['custobar_can_email'] ) && $posted['custobar_can_email'] ) ? true : false;
+		update_user_meta( $customer_id, '_woocommerce_custobar_can_email', $can_email );
+	}
+	if ( apply_filters( 'woocommerce_custobar_show_sms_permission_setting_checkout', true ) ) {
+		$can_sms = ( isset( $posted['custobar_can_sms'] ) && $posted['custobar_can_sms'] ) ? true : false;
+		update_user_meta( $customer_id, '_woocommerce_custobar_can_sms', $can_sms );
+	}
+
+}
+add_action( 'woocommerce_checkout_update_user_meta', __NAMESPACE__ . '\\woocommerce_checkout_update_user_meta', 10, 2 );

--- a/includes/my-account.php
+++ b/includes/my-account.php
@@ -1,0 +1,44 @@
+<?php
+namespace WooCommerceCustobar;
+
+// Add Marketing Permissions fields
+function woocommerce_edit_account_form_marketing_permissions() {
+	$allow_email_marketing_checked = get_user_meta( get_current_user_id(), '_woocommerce_custobar_can_email', true ) ? true : '';
+	$allow_sms_marketing_checked   = get_user_meta( get_current_user_id(), '_woocommerce_custobar_can_sms', true ) ? true : '';
+	if ( apply_filters( 'woocommerce_custobar_show_email_permission_setting_my_account', true ) ) : ?>
+	<p class="form-row form-row-wide">
+		<span class="woocommerce-input-wrapper">
+			<label for="custobar_can_email" class="checkbox">
+				<input type="checkbox" class="input-checkbox" name="custobar_can_email" id="custobar_can_email" <?php checked( $allow_email_marketing_checked, true, true ); ?>>
+				<?php esc_html_e( 'I would like to receive marketing messages via Email', 'woocommerce-custobar' ); ?>
+			</label>
+		</span> 
+	</p>
+	<?php endif; ?>
+	<?php if ( apply_filters( 'woocommerce_custobar_show_sms_permission_setting_my_account', true ) ) : ?>
+	<p class="form-row form-row-wide">
+		<span class="woocommerce-input-wrapper">
+			<label for="custobar_can_sms" class="checkbox">
+				<input type="checkbox" class="input-checkbox" name="custobar_can_sms" id="custobar_can_sms" <?php checked( $allow_sms_marketing_checked, true, true ); ?>>
+				<?php esc_html_e( 'I would like to receive marketing messages via SMS', 'woocommerce-custobar' ); ?>
+			</label>
+		</span> 
+	</p>
+		<?php
+	endif;
+}
+add_action( 'woocommerce_edit_account_form', __NAMESPACE__ . '\\woocommerce_edit_account_form_marketing_permissions' );
+
+// Save marketing permission fields as user meta
+function woocommerce_save_account_details( $customer_id ) {
+	if ( apply_filters( 'woocommerce_custobar_show_email_permission_setting_my_account', true ) ) {
+		$can_email = ( isset( $_POST['custobar_can_email'] ) && $_POST['custobar_can_email'] ) ? true : false; // @codingStandardsIgnoreLine
+		update_user_meta( $customer_id, '_woocommerce_custobar_can_email', $can_email );
+	}
+	if ( apply_filters( 'woocommerce_custobar_show_sms_permission_setting_my_account', true ) ) {
+		$can_sms = ( isset( $_POST['custobar_can_sms'] ) && $_POST['custobar_can_sms'] ) ? true : false; // @codingStandardsIgnoreLine
+		update_user_meta( $customer_id, '_woocommerce_custobar_can_sms', $can_sms );
+	}
+}
+add_action( 'woocommerce_save_account_details', __NAMESPACE__ . '\\woocommerce_save_account_details', 10, 1 );
+

--- a/woocommerce-custobar.php
+++ b/woocommerce-custobar.php
@@ -5,7 +5,7 @@
  * Description: Syncs your WooCommerce data with Custobar.
  * Author: Custobar
  * Text Domain: woocommerce-custobar
- * Version: 2.2.0
+ * Version: 2.3.0
  * Domain Path: /languages
  * WC requires at least: 4.0
  * Requires PHP 7.2+

--- a/woocommerce-custobar.php
+++ b/woocommerce-custobar.php
@@ -48,6 +48,7 @@ require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/data-sources/class-product.ph
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/data-sources/class-customer.php';
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/data-sources/class-sale.php';
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/data-sources/class-custobar-data-source.php';
+require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/rest-api/class-rest-marketing-permissions.php';
 
 // Add settings page
 add_filter(
@@ -65,6 +66,8 @@ register_deactivation_hook( __FILE__, array( 'WooCommerceCustobar\Plugin', 'deac
 // Initialize plugin after WooCommerce is loaded
 add_action( 'plugins_loaded', array( 'WooCommerceCustobar\Plugin', 'initialize' ) );
 
+// Initialize Rest API endpoint
+add_action( 'init', array( new \WooCommerceCustobar\RestAPI\REST_Marketing_Permissions(), 'init' ) );
+
 // Load translations
 add_action( 'init', 'WooCommerceCustobar\load_textdomain' );
-

--- a/woocommerce-custobar.php
+++ b/woocommerce-custobar.php
@@ -26,6 +26,8 @@ if ( ! defined( 'WOOCOMMERCE_CUSTOBAR_VERSION' ) ) {
 }
 
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/includes/functions.php';
+require_once WOOCOMMERCE_CUSTOBAR_PATH . '/includes/checkout.php';
+require_once WOOCOMMERCE_CUSTOBAR_PATH . '/includes/my-account.php';
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/class-plugin.php';
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/class-data-upload.php';
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/data-types/abstract-custobar-data-type.php';


### PR DESCRIPTION
Adds support for marketing permissions.

## Checkout and My Account

The permissions can be controlled by the customer at:

- Checkout
- My Account -> Account details -page

Please note that the can_email and can_sms fields are sent to Custobar every time the customer is updated. Essentially this means, that if marketing permissions have been controlled at Custobar only, you'd need update the settings for each customer **from** Custobar **to** WooCommerce before updating to version 2.3.0 of the plugin.

## Rest API and webhooks

This Pull Request also includes a custom Rest API endpoint that allows two-way sync from Custobar to WooCommerce using the Webhook feature of Custobar. 

The format of the incoming payload should be the following:

```
{
  "items": [
    {
      "external_id": "2", 
      "can_email": false, 
      "can_sms": false
    }
  ]
}
```

Please note that you'll also need to configure a Request header at Custobar. The name of the header field is _Authorization_ and the value of the field should be copied from the _Webhook Secret Key_ field in the _API settings_ section in WooCommerce admin panel.